### PR TITLE
Licencing tweak.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ For more information about CodeScene, see the [CodeScene Documentation](https://
 
 ### License, Liability & Support
 
- * Dockerfile and Image is provided under [MIT License](https://github.com/empear-analytics/docker-codescene-nginx-self-signed-ssl/blob/master/LICENSE.md)
+* The contents of this repository are provided under the [MIT License](https://github.com/empear-analytics/docker-codescene-nginx-self-signed-ssl/blob/master/LICENSE.md). Other licences may apply to the software contained in the Docker images referenced here.


### PR DESCRIPTION
Make sure that it is clear that CodeScene is not released under the
MIT license, even though it is part of one of the Docker images.