### PR TITLE
Make CodeScene download link configurable via build argument `CODESCENE_VERSION`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ The reverse proxy using Nginx is built like this:
     docker build -t reverseproxy docker-nginx/
 
 The CodeScene image should already be available from [Docker Hub](https://hub.docker.com/r/empear/debian-onprem/) under
-`empear/debian-onprem:latest`, but can also be built locally like this:
+`empear/debian-onprem:latest`, but can also be built locally like this (specify a proper CodeScene version):
 
-    docker build -t empear/debian-onprem docker-codescene/
+    docker build --build-arg CODESCENE_VERSION=2.X.Y -t empear/debian-onprem docker-codescene/
 
 ### Run
 

--- a/docker-codescene/Dockerfile
+++ b/docker-codescene/Dockerfile
@@ -13,7 +13,8 @@ RUN mkdir -p /analysis
 
 VOLUME /repos
 
-ADD https://s3-eu-west-1.amazonaws.com/downloads.codescene.io/enterprise/2.3.0/codescene-enterprise-edition.standalone.jar /opt/codescene/
+ARG CODESCENE_VERSION=2.5.0
+ADD https://downloads.codescene.io/enterprise/${CODESCENE_VERSION}/codescene-enterprise-edition.standalone.jar /opt/codescene/
 EXPOSE 3003
 CMD ["locale"]
 CMD [ "java", "-jar", "/opt/codescene/codescene-enterprise-edition.standalone.jar" ]


### PR DESCRIPTION
This way you can build a new image without actually changing the sources:
```
docker build --build-arg CODESCENE_VERSION=2.6.0 -t empear/debian-onprem docker-codescene/
```