### PR TITLE
ENTERPRISE-699: use ENTRYPOINT instead of CMD to run CodeScene.

### DIFF
--- a/docker-codescene/Dockerfile
+++ b/docker-codescene/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /analysis
 
 VOLUME /repos
 
-ARG CODESCENE_VERSION=2.5.0
+ARG CODESCENE_VERSION=2.5.1
 ADD https://downloads.codescene.io/enterprise/${CODESCENE_VERSION}/codescene-enterprise-edition.standalone.jar /opt/codescene/
 EXPOSE 3003
 CMD [ "java", "-jar", "/opt/codescene/codescene-enterprise-edition.standalone.jar" ]

--- a/docker-codescene/Dockerfile
+++ b/docker-codescene/Dockerfile
@@ -16,5 +16,4 @@ VOLUME /repos
 ARG CODESCENE_VERSION=2.5.0
 ADD https://downloads.codescene.io/enterprise/${CODESCENE_VERSION}/codescene-enterprise-edition.standalone.jar /opt/codescene/
 EXPOSE 3003
-CMD ["locale"]
 CMD [ "java", "-jar", "/opt/codescene/codescene-enterprise-edition.standalone.jar" ]

--- a/docker-codescene/Dockerfile
+++ b/docker-codescene/Dockerfile
@@ -16,4 +16,4 @@ VOLUME /repos
 ARG CODESCENE_VERSION=2.5.1
 ADD https://downloads.codescene.io/enterprise/${CODESCENE_VERSION}/codescene-enterprise-edition.standalone.jar /opt/codescene/
 EXPOSE 3003
-CMD [ "java", "-jar", "/opt/codescene/codescene-enterprise-edition.standalone.jar" ]
+ENTRYPOINT [ "java", "-jar", "/opt/codescene/codescene-enterprise-edition.standalone.jar" ]


### PR DESCRIPTION

ENTRYPOINT is more suitable since we're building special-purpose image, not a general-purpose one.
See https://stackoverflow.com/questions/21553353/what-is-the-difference-between-cmd-and-entrypoint-in-a-dockerfile

Check trello: https://trello.com/c/5c4wuesT/669-use-entrypoint-instead-of-cmd-in-codescene-docker-image