### PR TITLE
Updates for the 3.0.5 release - JDK 11, RAM utilization, proxy_read_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The reverse proxy using Nginx is built like this:
 The CodeScene image should already be available from [Docker Hub](https://hub.docker.com/r/empear/ubuntu-onprem/) under
 `empear/ubuntu-onprem:latest`, but can also be built locally like this (specify a proper CodeScene version):
 
-    docker build --build-arg CODESCENE_VERSION=2.X.Y -t empear/ubuntu-onprem docker-codescene/
+    docker build --build-arg CODESCENE_VERSION=3.X.Y -t empear/ubuntu-onprem docker-codescene/
 
 ## Run
 

--- a/docker-codescene/Dockerfile
+++ b/docker-codescene/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.10
 
-RUN apt-get update; apt-get install -y git openjdk-8-jre
+RUN apt-get update; apt-get install -y git openjdk-11-jdk
 RUN apt-get install -y locales 
 
 ## because this is Docker, we can just set these without bothering

--- a/docker-codescene/Dockerfile
+++ b/docker-codescene/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /codescene/analysis
 RUN mkdir -p /codescene/repos
 RUN mkdir -p /codescene/log
 
-ARG CODESCENE_VERSION=3.0.2
+ARG CODESCENE_VERSION=3.0.5
 ADD https://downloads.codescene.io/enterprise/${CODESCENE_VERSION}/codescene-enterprise-edition.standalone.jar /opt/codescene/
 EXPOSE 3003
 

--- a/docker-codescene/Dockerfile
+++ b/docker-codescene/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /codescene/analysis
 RUN mkdir -p /codescene/repos
 RUN mkdir -p /codescene/log
 
-ARG CODESCENE_VERSION=2.8.2
+ARG CODESCENE_VERSION=3.0.2
 ADD https://downloads.codescene.io/enterprise/${CODESCENE_VERSION}/codescene-enterprise-edition.standalone.jar /opt/codescene/
 EXPOSE 3003
 

--- a/docker-codescene/start-codescene.sh
+++ b/docker-codescene/start-codescene.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -XshowSettings:vm $JAVA_OPTIONS -jar "/opt/codescene/codescene-enterprise-edition.standalone.jar" | tee -a /codescene/codescene.log
+java -XshowSettings:vm $JAVA_OPTIONS -XX:MaxRAMPercentage=60 -jar "/opt/codescene/codescene-enterprise-edition.standalone.jar" | tee -a /codescene/codescene.log

--- a/docker-nginx/nginx.conf
+++ b/docker-nginx/nginx.conf
@@ -19,6 +19,8 @@ http {
 
   tcp_nopush on;
   tcp_nodelay on;
+  # increase read timeout to avoid 504 when cloning larger repos on the "New Project" page
+  proxy_read_timeout 600;
   keepalive_timeout 65;
   types_hash_max_size 2048;
 


### PR DESCRIPTION
* Default codescene version set to the latest 3.0.5
* Increases nginx' `proxy_read_timeout` to 10 mins to avoid 504 when cloning larger repos on the "New Project" page (the difference can be observed when cloning https://github.com/junit-team/junit5.git)
* Upgrades to Ubuntu 18.10 and OpenJDK 11 for better memory utilization via `-XX:MaxRAMPercentage=60`
* Full JDK included
  => handy JDK tools like `jmcd` are available - great for monitoring and troubleshooting
  => image is larger (~+200 due to JRE vs JDK difference + <100 MB due to Ubuntu distributions difference)