### PR TITLE
Ensure creation of analysis and repo directories at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ The reverse proxy using Nginx is built like this:
 The CodeScene image should already be available from [Docker Hub](https://hub.docker.com/r/empear/ubuntu-onprem/) under
 `empear/ubuntu-onprem:latest`, but can also be built locally like this (specify a proper CodeScene version):
 
-    docker build --build-arg CODESCENE_VERSION=3.X.Y -t empear/ubuntu-onprem docker-codescene/
+    docker build -t empear/ubuntu-onprem docker-codescene/
 
+If you want to use a specific version of CodeScene, you can add a `--build-arg`:
+
+    docker build  --build-arg CODESCENE_VERSION=3.X.Y -t empear/ubuntu-onprem docker-codescene/
+	
 ## Run
 
 ### Run CodeScene behind the reverse proxy

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The reverse proxy using Nginx is built like this:
     docker build -t reverseproxy docker-nginx/
 
 The CodeScene image should already be available from [Docker Hub](https://hub.docker.com/r/empear/ubuntu-onprem/) under
-`empear/ubuntu-onprem:latest`, but can also be built locally like this (specify a proper CodeScene version):
+`empear/ubuntu-onprem:latest`, but can also be built locally like this:
 
     docker build -t empear/ubuntu-onprem docker-codescene/
 

--- a/docker-codescene/Dockerfile
+++ b/docker-codescene/Dockerfile
@@ -14,9 +14,6 @@ ENV LC_ALL C.UTF-8
 ENV LC_CTYPE C.UTF-8
 
 RUN mkdir -p /opt/codescene
-RUN mkdir -p /codescene/analysis
-RUN mkdir -p /codescene/repos
-RUN mkdir -p /codescene/log
 
 ARG CODESCENE_VERSION=3.0.6
 ADD https://downloads.codescene.io/enterprise/${CODESCENE_VERSION}/codescene-enterprise-edition.standalone.jar /opt/codescene/
@@ -26,8 +23,9 @@ EXPOSE 3003
 ADD start-codescene.sh /start-codescene.sh
 RUN chmod 755 /start-codescene.sh
 
-ENV CODESCENE_DB_PATH=/codescene/codescene
-ENV CODESCENE_ANALYSIS_RESULTS_ROOT=/codescene/analysis
-ENV CODESCENE_CLONED_REPOSITORIES_ROOT=/codescene/repos
+ENV CODESCENE_DIR /codescene
+ENV CODESCENE_DB_PATH=${CODESCENE_DIR}/codescene
+ENV CODESCENE_ANALYSIS_RESULTS_ROOT=${CODESCENE_DIR}/analysis
+ENV CODESCENE_CLONED_REPOSITORIES_ROOT=${CODESCENE_DIR}/repos
 
 ENTRYPOINT [ "/start-codescene.sh" ]

--- a/docker-codescene/start-codescene.sh
+++ b/docker-codescene/start-codescene.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mkdir -p $CODESCENE_ANALYSIS_RESULTS_ROOT
-mkdir -p $CODESCENE_CLOSED_REPOSITORIES_ROOT
+mkdir -p $CODESCENE_CLONED_REPOSITORIES_ROOT
 java -XshowSettings:vm $JAVA_OPTIONS -XX:MaxRAMPercentage=60 -jar "/opt/codescene/codescene-enterprise-edition.standalone.jar" | tee -a ${CODESCENE_DIR}/codescene.log

--- a/docker-codescene/start-codescene.sh
+++ b/docker-codescene/start-codescene.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-java -XshowSettings:vm $JAVA_OPTIONS -XX:MaxRAMPercentage=60 -jar "/opt/codescene/codescene-enterprise-edition.standalone.jar" | tee -a /codescene/codescene.log
+mkdir -p $CODESCENE_ANALYSIS_RESULTS_ROOT
+mkdir -p $CODESCENE_CLOSED_REPOSITORIES_ROOT
+java -XshowSettings:vm $JAVA_OPTIONS -XX:MaxRAMPercentage=60 -jar "/opt/codescene/codescene-enterprise-edition.standalone.jar" | tee -a ${CODESCENE_DIR}/codescene.log


### PR DESCRIPTION
These directories were being created in the Dockerfile at build time
but then (we think) clobbered when the /codescene volume was mounted.