### PR TITLE
Quote JAVA_OPTIONS in Dockerfile to fix special characters.

### DIFF
--- a/docker-codescene/Dockerfile
+++ b/docker-codescene/Dockerfile
@@ -6,6 +6,9 @@ RUN echo "deb http://security.ubuntu.com/ubuntu/ bionic-security main restricted
 
 RUN apt-get update; apt-get install -y git openjdk-11-jdk locales libcurl3-gnutls=7.58.0*
 
+# debugging utilities
+RUN apt-get install -y netcat rlwrap
+
 ## because this is Docker, we can just set these without bothering
 ## with most of the locale infrastructure
 ENV LANG C.UTF-8

--- a/docker-codescene/start-codescene.sh
+++ b/docker-codescene/start-codescene.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mkdir -p $CODESCENE_ANALYSIS_RESULTS_ROOT
 mkdir -p $CODESCENE_CLONED_REPOSITORIES_ROOT
-java -XshowSettings:vm $JAVA_OPTIONS -XX:MaxRAMPercentage=60 -Duser.timezone="$CODESCENE_TIMEZONE" -jar "/opt/codescene/codescene-enterprise-edition.standalone.jar" | tee -a ${CODESCENE_DIR}/codescene.log
+java -XshowSettings:vm "$JAVA_OPTIONS" -XX:MaxRAMPercentage=60 -Duser.timezone="$CODESCENE_TIMEZONE" -jar "/opt/codescene/codescene-enterprise-edition.standalone.jar" | tee -a ${CODESCENE_DIR}/codescene.log


### PR DESCRIPTION
E.g. when running with socket repl it didn't work when the var was
defined inside the docker-compose.yml file as this:
```
  - 'JAVA_OPTIONS=-Dclojure.server.repl={:port 5555 :accept
clojure.core.server/repl}'
```

With this change it works without problems.