### PR TITLE
Raise default MaxRAMPercentage to 75%.

### DIFF
--- a/docker-codescene/Dockerfile
+++ b/docker-codescene/Dockerfile
@@ -18,7 +18,7 @@ ENV LC_CTYPE C.UTF-8
 
 RUN mkdir -p /opt/codescene
 
-ARG CODESCENE_VERSION=4.0.2
+ARG CODESCENE_VERSION=4.0.5
 ADD https://downloads.codescene.io/enterprise/${CODESCENE_VERSION}/codescene-enterprise-edition.standalone.jar /opt/codescene/
 EXPOSE 3003
 

--- a/docker-codescene/start-codescene.sh
+++ b/docker-codescene/start-codescene.sh
@@ -4,4 +4,4 @@ set -x
 mkdir -p $CODESCENE_ANALYSIS_RESULTS_ROOT
 mkdir -p $CODESCENE_CLONED_REPOSITORIES_ROOT
 # don't quote "$JAVA_OPTIONS" because you wouldn't be able to use it for multiple properties/settings in docker-compose.yml
-java -XshowSettings:vm $JAVA_OPTIONS -XX:MaxRAMPercentage=60 -Duser.timezone="$CODESCENE_TIMEZONE" -jar "/opt/codescene/codescene-enterprise-edition.standalone.jar" | tee -a ${CODESCENE_DIR}/codescene.log
+java -XshowSettings:vm $JAVA_OPTIONS -XX:MaxRAMPercentage=75 -Duser.timezone="$CODESCENE_TIMEZONE" -jar "/opt/codescene/codescene-enterprise-edition.standalone.jar" | tee -a ${CODESCENE_DIR}/codescene.log


### PR DESCRIPTION
In docker environment it should be pretty safe to use higher portion of total RAM for the heap.
Especially because total RAM should be usually gigabytes (we recommend at least 4 GB).